### PR TITLE
perf: Improve Xor method performance by ~20% for big sets

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -258,26 +258,47 @@ func BenchmarkXor(b *testing.B) {
 }
 
 func BenchmarkBitSet_Xor(b *testing.B) {
-	small1, small2 := New(1, 2, 3, 4, 5), New(3, 4, 5, 6, 7)
-	large1, large2 := New(), New()
-	for i := range 10000 {
-		if i%2 == 0 {
-			large1.Add(i)
-		}
-		if i%3 == 0 {
-			large2.Add(i)
-		}
-	}
-
-	b.Run("small sets", func(b *testing.B) {
+	b.Run("empty", func(b *testing.B) {
+		s1, s2 := New(), New()
 		for b.Loop() {
-			small1.Xor(small2)
+			s1.Xor(s2)
 		}
 	})
 
-	b.Run("large sets", func(b *testing.B) {
+	b.Run("5", func(b *testing.B) {
+		s1, s2 := New(1, 2, 3, 4, 5), New(3, 4, 5, 6, 7)
 		for b.Loop() {
-			large1.Xor(large2)
+			s1.Xor(s2)
+		}
+	})
+
+	b.Run("10k", func(b *testing.B) {
+		s1, s2 := New(), New()
+		for i := range 10_000 {
+			switch {
+			case i%2 == 0:
+				s1.Add(i)
+			case i%3 == 0:
+				s2.Add(i)
+			}
+		}
+		for b.Loop() {
+			s1.Xor(s2)
+		}
+	})
+
+	b.Run("1m", func(b *testing.B) {
+		s1, s2 := New(), New()
+		for i := range 1_000_000 {
+			switch {
+			case i%2 == 0:
+				s1.Add(i)
+			case i%3 == 0:
+				s2.Add(i)
+			}
+		}
+		for b.Loop() {
+			s1.Xor(s2)
 		}
 	})
 }

--- a/bitset.go
+++ b/bitset.go
@@ -393,7 +393,7 @@ func Or(s1, s2 BitSet) BitSet {
 		return BitSet{}
 	}
 	if otherLen == 0 { // s2 is empty, return a copy of s1 with trailing zeros removed
-		var last = bsLen - 1
+		last := bsLen - 1
 		for last >= 0 && s1[last] == 0 {
 			last--
 		}
@@ -468,8 +468,27 @@ func (bs *BitSet) Xor(other BitSet) {
 	if len(other) > len(*bs) {
 		bs.resize(len(other))
 	}
-	for i := 0; i < len(other); i++ {
-		(*bs)[i] ^= other[i]
+	if len(other) < 8 {
+		for i := range other {
+			(*bs)[i] ^= other[i]
+		}
+		bs.trim()
+		return
+	}
+
+	b := *bs
+	for ; len(other) > 7; b, other = b[8:], other[8:] {
+		(b)[0] ^= other[0]
+		(b)[1] ^= other[1]
+		(b)[2] ^= other[2]
+		(b)[3] ^= other[3]
+		(b)[4] ^= other[4]
+		(b)[5] ^= other[5]
+		(b)[6] ^= other[6]
+		(b)[7] ^= other[7]
+	}
+	for i := range other {
+		b[i] ^= other[i]
 	}
 	bs.trim()
 }


### PR DESCRIPTION
Handling larger bitsets in 8-batches is more efficient on modern CPUs.
I assume it's related to instruction-level parallelism.
This technique can effectively be applied to most bitset methods and functions.

```
goos: darwin
goarch: arm64
pkg: github.com/KernelPryanic/bitmask
cpu: Apple M1 Max
                    │   old.txt   │              new.txt               │
                    │   sec/op    │   sec/op     vs base               │
BitSet_Xor/empty-10   2.498n ± 4%   2.493n ± 3%        ~ (p=0.372 n=6)
BitSet_Xor/5-10       2.491n ± 1%   2.492n ± 1%        ~ (p=0.729 n=6)
BitSet_Xor/10k-10     76.10n ± 1%   49.79n ± 1%  -34.57% (p=0.002 n=6)
BitSet_Xor/1m-10      8.453µ ± 0%   5.112µ ± 1%  -39.52% (p=0.002 n=6)
geomean               44.73n        35.46n       -20.72%

                    │   old.txt    │              new.txt               │
                    │     B/op     │    B/op     vs base                │
BitSet_Xor/empty-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
BitSet_Xor/5-10       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
BitSet_Xor/10k-10     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
BitSet_Xor/1m-10      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                          ²               +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                    │   old.txt    │              new.txt               │
                    │  allocs/op   │ allocs/op   vs base                │
BitSet_Xor/empty-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
BitSet_Xor/5-10       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
BitSet_Xor/10k-10     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
BitSet_Xor/1m-10      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                          ²               +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```